### PR TITLE
Add OpenAI service tier parameter

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -46,6 +46,8 @@ pub struct AvailableModel {
     pub max_tokens: usize,
     pub max_output_tokens: Option<u32>,
     pub max_completion_tokens: Option<u32>,
+    #[serde(default)]
+    pub service_tier: Option<open_ai::ServiceTier>,
 }
 
 pub struct OpenAiLanguageModelProvider {
@@ -213,6 +215,7 @@ impl LanguageModelProvider for OpenAiLanguageModelProvider {
                     max_tokens: model.max_tokens,
                     max_output_tokens: model.max_output_tokens,
                     max_completion_tokens: model.max_completion_tokens,
+                    service_tier: model.service_tier,
                 },
             );
         }
@@ -437,6 +440,7 @@ pub fn into_open_ai(
         stream,
         stop: request.stop,
         temperature: request.temperature.unwrap_or(1.0),
+        service_tier: model.service_tier(),
         max_tokens: max_output_tokens,
         parallel_tool_calls: if model.supports_parallel_tool_calls() && !request.tools.is_empty() {
             // Disable parallel tool calls, as the Agent currently expects a maximum of one per turn.

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -220,12 +220,14 @@ impl OpenAiSettingsContent {
                                     max_tokens,
                                     max_output_tokens,
                                     max_completion_tokens,
+                                    service_tier,
                                 } => Some(provider::open_ai::AvailableModel {
                                     name,
                                     max_tokens,
                                     max_output_tokens,
                                     display_name,
                                     max_completion_tokens,
+                                    service_tier,
                                 }),
                                 _ => None,
                             })

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -54,6 +54,20 @@ impl From<Role> for String {
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceTier {
+    Auto,
+    Flex,
+}
+
+impl Default for ServiceTier {
+    fn default() -> Self {
+        ServiceTier::Auto
+    }
+}
+
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
     #[serde(rename = "gpt-3.5-turbo", alias = "gpt-3.5-turbo")]
@@ -94,6 +108,8 @@ pub enum Model {
         max_tokens: usize,
         max_output_tokens: Option<u32>,
         max_completion_tokens: Option<u32>,
+        #[serde(default)]
+        service_tier: Option<ServiceTier>,
     },
 }
 
@@ -193,6 +209,13 @@ impl Model {
         }
     }
 
+    pub fn service_tier(&self) -> ServiceTier {
+        match self {
+            Self::Custom { service_tier, .. } => service_tier.unwrap_or_default(),
+            _ => ServiceTier::Auto,
+        }
+    }
+
     /// Returns whether the given model supports the `parallel_tool_calls` parameter.
     ///
     /// If the model does not support the parameter, do not pass it up, or the API will return an error.
@@ -222,6 +245,8 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stop: Vec<String>,
     pub temperature: f32,
+    #[serde(default)]
+    pub service_tier: ServiceTier,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
     /// Whether to enable parallel function calling during tool use.

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -413,6 +413,12 @@ To use alternate models, perhaps a preview release or a dated model release, or 
           "display_name": "o1-mini",
           "max_tokens": 128000,
           "max_completion_tokens": 20000
+        },
+        {
+          "name": "o3",
+          "display_name": "o3",
+          "max_tokens": 200000,
+          "service_tier": "flex"
         }
       ],
       "version": "1"
@@ -423,6 +429,9 @@ To use alternate models, perhaps a preview release or a dated model release, or 
 
 You must provide the model's Context Window in the `max_tokens` parameter; this can be found in the [OpenAI model documentation](https://platform.openai.com/docs/models).
 OpenAI `o1` models should set `max_completion_tokens` as well to avoid incurring high reasoning token costs.
+The `service_tier` option controls the [OpenAI service tier](https://platform.openai.com/docs/overview/rate-limits#service-tiers) used for the model.
+If omitted, it defaults to `auto`.
+Only some models, like `o4-mini` and `o3`, currently support setting this option to `flex`.
 Custom models will be listed in the model dropdown in the Agent Panel.
 
 ### OpenRouter {#openrouter}


### PR DESCRIPTION
## Summary
- add `ServiceTier` enum to OpenAI requests and models
- allow configuring `service_tier` in OpenAI model settings
- include the parameter when building OpenAI requests
- document the new option with an example configuration
- derive `JsonSchema` for `ServiceTier`

## Testing
- `cargo fmt --all`
- `cargo check -p open_ai -p language_models`


------
https://chatgpt.com/codex/tasks/task_e_6841d5ed834c8332adc391324eaf1fa5